### PR TITLE
Update to support latest Blender + Vulkan backend

### DIFF
--- a/ImguiExample/blender_imgui.py
+++ b/ImguiExample/blender_imgui.py
@@ -20,7 +20,6 @@
 
 import bpy
 from bpy.types import SpaceView3D
-import bgl as gl
 import gpu
 from gpu_extras.batch import batch_for_shader
 
@@ -35,50 +34,37 @@ import ctypes as C
 
 class BlenderImguiRenderer(BaseOpenGLRenderer):
     """Integration of ImGui into Blender."""
-
     VERTEX_SHADER_SRC = """
-    uniform mat4 ProjMtx;
-    in vec2 Position;
-    in vec2 UV;
-    in vec4 Color;
-    out vec2 Frag_UV;
-    out vec4 Frag_Color;
+        void main() {
+            Frag_UV = UV;
+            Frag_Color = Color;
 
-    void main() {
-        Frag_UV = UV;
-        Frag_Color = Color;
-
-        gl_Position = ProjMtx * vec4(Position.xy, 0, 1);
-    }
-    """
+            gl_Position = ProjMtx * vec4(Position.xy, 0, 1);
+        }
+        """
 
     FRAGMENT_SHADER_SRC = """
-    uniform sampler2D Texture;
-    in vec2 Frag_UV;
-    in vec4 Frag_Color;
-    out vec4 Out_Color;
+        vec4 linear_to_srgb(vec4 linear) {
+            return mix(
+                1.055 * pow(linear, vec4(1.0 / 2.4)) - 0.055,
+                12.92 * linear,
+                step(linear, vec4(0.00031308))
+            );
+        }
 
-    vec4 linear_to_srgb(vec4 linear) {
-        return mix(
-            1.055 * pow(linear, vec4(1.0 / 2.4)) - 0.055,
-            12.92 * linear,
-            step(linear, vec4(0.00031308))
-        );
-    }
+        vec4 srgb_to_linear(vec4 srgb) {
+            return mix(
+                pow((srgb + 0.055) / 1.055, vec4(2.4)),
+                srgb / 12.92,
+                step(srgb, vec4(0.04045))
+            );
+        }
 
-    vec4 srgb_to_linear(vec4 srgb) {
-        return mix(
-            pow((srgb + 0.055) / 1.055, vec4(2.4)),
-            srgb / 12.92,
-            step(srgb, vec4(0.04045))
-        );
-    }
-
-    void main() {
-        Out_Color = Frag_Color * texture(Texture, Frag_UV.st);
-        Out_Color.rgba = srgb_to_linear(Out_Color.rgba);
-    }
-    """
+        void main() {
+            Out_Color = Frag_Color * texture(Texture, Frag_UV.st);
+            Out_Color.rgba = srgb_to_linear(Out_Color.rgba);
+        }
+        """
 
     def __init__(self):
         self._shader_handle = None
@@ -95,37 +81,46 @@ class BlenderImguiRenderer(BaseOpenGLRenderer):
         self._elements_handle = None
         self._vao_handle = None
 
+        self._texture : gpu.types.GPUTexture = None
+
         super().__init__()
 
     def refresh_font_texture(self):
-        # save texture state
-        buf = gl.Buffer(gl.GL_INT, 1)
-        gl.glGetIntegerv(gl.GL_TEXTURE_BINDING_2D, buf)
-        last_texture = buf[0]
+        self.io.fonts.add_font_default()
+        self.io.fonts.get_tex_data_as_rgba32()
 
-        width, height, pixels = self.io.fonts.get_tex_data_as_rgba32()
+        width, height, imgui_pixels = self.io.fonts.get_tex_data_as_rgba32()
 
-        if self._font_texture is not None:
-            gl.glDeleteTextures([self._font_texture])
+        pixels_float = np.frombuffer(imgui_pixels, dtype=np.uint8)
+        pixels_float = pixels_float.astype('f') / 255.0
 
-        gl.glGenTextures(1, buf)
-        self._font_texture = buf[0]
+        buffer = gpu.types.Buffer('FLOAT', 4 * width * height, pixels_float)
+        self._texture = gpu.types.GPUTexture(size=(width, height), data=buffer, format='RGBA32F')
 
-        gl.glBindTexture(gl.GL_TEXTURE_2D, self._font_texture)
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
-        
-        pixel_buffer = gl.Buffer(gl.GL_BYTE, [4 * width * height])
-        pixel_buffer[:] = pixels
-        gl.glTexImage2D(gl.GL_TEXTURE_2D, 0, gl.GL_RGBA, width, height, 0, gl.GL_RGBA, gl.GL_UNSIGNED_BYTE, pixel_buffer)
-
-        self.io.fonts.texture_id = self._font_texture
-        gl.glBindTexture(gl.GL_TEXTURE_2D, last_texture)
+        self.io.fonts.texture_id = self._texture
         self.io.fonts.clear_tex_data()
 
     def _create_device_objects(self):
-        self._bl_shader = gpu.types.GPUShader(self.VERTEX_SHADER_SRC, self.FRAGMENT_SHADER_SRC)
-        
+        shader_info = gpu.types.GPUShaderCreateInfo()
+        shader_vertex_outs = gpu.types.GPUStageInterfaceInfo("imgui_shader_interface")
+        shader_info.push_constant('MAT4', "ProjMtx")
+        shader_info.vertex_in(0, 'VEC2', "Position")
+        shader_info.vertex_in(1, 'VEC2', "UV")
+        shader_info.vertex_in(2, 'VEC4', "Color")
+        shader_vertex_outs.no_perspective('VEC2', "Frag_UV")
+        shader_vertex_outs.no_perspective('VEC4', "Frag_Color")
+        shader_info.vertex_out(shader_vertex_outs)
+        shader_info.sampler(0,'FLOAT_2D', "Texture")
+        shader_info.fragment_out(0,'VEC4', "Out_Color")
+
+        shader_info.vertex_source(self.VERTEX_SHADER_SRC)
+        shader_info.fragment_source(self.FRAGMENT_SHADER_SRC)
+
+        shader = gpu.shader.create_from_info(shader_info)
+        self._bl_shader = shader
+        del shader_info
+        del shader_vertex_outs
+
     def render(self, draw_data):
         io = self.io
         shader = self._bl_shader
@@ -139,49 +134,13 @@ class BlenderImguiRenderer(BaseOpenGLRenderer):
 
         draw_data.scale_clip_rects(*io.display_fb_scale)
 
-        # backup GL state
-        (
-            last_program,
-            last_texture,
-            last_active_texture,
-            last_array_buffer,
-            last_element_array_buffer,
-            last_vertex_array,
-            last_blend_src,
-            last_blend_dst,
-            last_blend_equation_rgb,
-            last_blend_equation_alpha,
-            last_viewport,
-            last_scissor_box,
-        ) = self._backup_integers(
-            gl.GL_CURRENT_PROGRAM, 1,
-            gl.GL_TEXTURE_BINDING_2D, 1,
-            gl.GL_ACTIVE_TEXTURE, 1,
-            gl.GL_ARRAY_BUFFER_BINDING, 1,
-            gl.GL_ELEMENT_ARRAY_BUFFER_BINDING, 1,
-            gl.GL_VERTEX_ARRAY_BINDING, 1,
-            gl.GL_BLEND_SRC, 1,
-            gl.GL_BLEND_DST, 1,
-            gl.GL_BLEND_EQUATION_RGB, 1,
-            gl.GL_BLEND_EQUATION_ALPHA, 1,
-            gl.GL_VIEWPORT, 4,
-            gl.GL_SCISSOR_BOX, 4,
-        )
-        
-        last_enable_blend = gl.glIsEnabled(gl.GL_BLEND)
-        last_enable_cull_face = gl.glIsEnabled(gl.GL_CULL_FACE)
-        last_enable_depth_test = gl.glIsEnabled(gl.GL_DEPTH_TEST)
-        last_enable_scissor_test = gl.glIsEnabled(gl.GL_SCISSOR_TEST)
+        last_blend = gpu.state.blend_get()
 
-        gl.glEnable(gl.GL_BLEND)
-        gl.glBlendEquation(gl.GL_FUNC_ADD)
-        gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
-        gl.glDisable(gl.GL_CULL_FACE)
-        gl.glDisable(gl.GL_DEPTH_TEST)
-        gl.glEnable(gl.GL_SCISSOR_TEST)
-        gl.glActiveTexture(gl.GL_TEXTURE0)
+        gpu.state.blend_set('ALPHA')
+        gpu.state.face_culling_set('NONE')
+        gpu.state.scissor_test_set(True)
 
-        gl.glViewport(0, 0, int(fb_width), int(fb_height))
+        gpu.state.viewport_set(0, 0, int(fb_width), int(fb_height))
 
         ortho_projection = (
              2.0/display_width, 0.0,                   0.0, 0.0,
@@ -192,92 +151,55 @@ class BlenderImguiRenderer(BaseOpenGLRenderer):
         shader.bind()
         shader.uniform_float("ProjMtx", ortho_projection)
         shader.uniform_int("Texture", 0)
-        
+
         for commands in draw_data.commands_lists:
             size = commands.idx_buffer_size * imgui.INDEX_SIZE // 4
             address = commands.idx_buffer_data
             ptr = C.cast(address, C.POINTER(C.c_int))
             idx_buffer_np = np.ctypeslib.as_array(ptr, shape=(size,))
-            
+
             size = commands.vtx_buffer_size * imgui.VERTEX_SIZE // 4
             address = commands.vtx_buffer_data
             ptr = C.cast(address, C.POINTER(C.c_float))
             vtx_buffer_np = np.ctypeslib.as_array(ptr, shape=(size,))
             vtx_buffer_shaped = vtx_buffer_np.reshape(-1, imgui.VERTEX_SIZE // 4)
-            
+
             idx_buffer_offset = 0
             for command in commands.commands:
                 x, y, z, w = command.clip_rect
-                gl.glScissor(int(x), int(fb_height - w), int(z - x), int(w - y))
-                
-                vertices = vtx_buffer_shaped[:,:2]
-                uvs = vtx_buffer_shaped[:,2:4]
-                colors = vtx_buffer_shaped.view(np.uint8)[:,4*4:]
+                gpu.state.scissor_set(int(x), int(fb_height - w), int(z - x), int(w - y))
+
+                vertices = vtx_buffer_shaped[:, :2]
+                uvs = vtx_buffer_shaped[:, 2:4]
+                colors = vtx_buffer_shaped.view(np.uint8)[:, 4 * 4:]
                 colors = colors.astype('f') / 255.0
-                
-                indices = idx_buffer_np[idx_buffer_offset:idx_buffer_offset+command.elem_count]
-                
-                gl.glBindTexture(gl.GL_TEXTURE_2D, command.texture_id)
-                
+
+                indices = idx_buffer_np[idx_buffer_offset:idx_buffer_offset + command.elem_count]
+
+                shader.uniform_sampler("Texture", command.texture_id)
+
                 batch = batch_for_shader(shader, 'TRIS', {
                     "Position": vertices,
                     "UV": uvs,
                     "Color": colors,
                 }, indices=indices)
                 batch.draw(shader)
-                
+
                 idx_buffer_offset += command.elem_count
 
-        # restore modified GL state
-        gl.glUseProgram(last_program)
-        gl.glActiveTexture(last_active_texture)
-        gl.glBindTexture(gl.GL_TEXTURE_2D, last_texture)
-        gl.glBindVertexArray(last_vertex_array)
-        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, last_array_buffer)
-        gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, last_element_array_buffer)
-        gl.glBlendEquationSeparate(last_blend_equation_rgb, last_blend_equation_alpha)
-        gl.glBlendFunc(last_blend_src, last_blend_dst)
-        
-        if last_enable_blend:
-            gl.glEnable(gl.GL_BLEND)
-        else:
-            gl.glDisable(gl.GL_BLEND)
+        # restore modified gpu state
+        gpu.state.blend_set(last_blend)
+        gpu.state.scissor_test_set(False)
 
-        if last_enable_cull_face:
-            gl.glEnable(gl.GL_CULL_FACE)
-        else:
-            gl.glDisable(gl.GL_CULL_FACE)
-
-        if last_enable_depth_test:
-            gl.glEnable(gl.GL_DEPTH_TEST)
-        else:
-            gl.glDisable(gl.GL_DEPTH_TEST)
-
-        if last_enable_scissor_test:
-            gl.glEnable(gl.GL_SCISSOR_TEST)
-        else:
-            gl.glDisable(gl.GL_SCISSOR_TEST)
-
-        gl.glViewport(last_viewport[0], last_viewport[1], last_viewport[2], last_viewport[3])
-        gl.glScissor(last_scissor_box[0], last_scissor_box[1], last_scissor_box[2], last_scissor_box[3])
-        
-
+    # Blender's GPU api seems to manage state fine enough,
+    # or at least much better than with BGL.
+    # Until proven otherwise, texture cleanup and state backup are removed.
     def _invalidate_device_objects(self):
-        if self._font_texture > -1:
-            gl.glDeleteTextures([self._font_texture])
-        self.io.fonts.texture_id = 0
-        self._font_texture = 0
+        pass
 
     def _backup_integers(self, *keys_and_lengths):
-        """Helper to back up opengl state"""
-        keys = keys_and_lengths[::2]
-        lengths = keys_and_lengths[1::2]
-        buf = gl.Buffer(gl.GL_INT, max(lengths))
-        values = []
-        for k, n in zip(keys, lengths):
-            gl.glGetIntegerv(k, buf)
-            values.append(buf[0] if n == 1 else buf[:n])
-        return values
+        pass
+
 
 # -------------------------------------------------------------------
 
@@ -302,10 +224,10 @@ class GlobalImgui:
         self.draw_handlers = {}
         self.callbacks = {}
         self.next_callback_id = 0
-        
+
     def shutdown_imgui(self):
         for SpaceType, draw_handler in self.draw_handlers.items():
-            SpaceType.draw_handler_remove(self.draw_handler, 'WINDOW')
+            SpaceType.draw_handler_remove(draw_handler, 'WINDOW')
         imgui.destroy_context(self.imgui_ctx)
         self.imgui_ctx = None
 
@@ -383,13 +305,16 @@ class GlobalImgui:
             # because imgui requires the key_map to contain integers only
             io.key_map[k] = k
 
+
 # -------------------------------------------------------------------
 
 def imgui_handler_add(callback, SpaceType):
     return GlobalImgui.get().handler_add(callback, SpaceType)
 
+
 def imgui_handler_remove(handle):
     GlobalImgui.get().handler_remove(handle)
+
 
 # -------------------------------------------------------------------
 
@@ -427,7 +352,7 @@ class ImguiBasedOperator:
 
     def init_imgui(self, context):
         self.imgui_handle = imgui_handler_add(self.draw, SpaceView3D)
-        
+
     def shutdown_imgui(self):
         imgui_handler_remove(self.imgui_handle)
 
@@ -439,7 +364,7 @@ class ImguiBasedOperator:
     def modal_imgui(self, context, event):
         region = context.region
         io = imgui.get_io()
-        
+
         io.mouse_pos = (event.mouse_region_x, region.height - 1 - event.mouse_region_y)
 
         if event.type == 'LEFTMOUSE':
@@ -457,7 +382,8 @@ class ImguiBasedOperator:
         elif event.type == 'WHEELUPDOWN':
             io.mouse_wheel = +1
 
-        print(f"Event type={event.type}, unicode={event.unicode}")
+        # Enable this for debugging, otherwise it just floods the console and increases our memory footprint
+        # print(f"Event type={event.type}, unicode={event.unicode}")
 
         if event.type in self.key_map:
             if event.value == 'PRESS':


### PR DESCRIPTION
This update migrates the implementation from using opengl directly--through blender's now-deprecated `bgl` module--to blender's `gpu` module, allowing it to work on both the latest versions of Blender and the new Vulkan backend available in the 4.5 alpha (at time of writing).

Some caveats:

-  The GPU module seems to manage state decently better than using OpenGL directly, so some memory management that was necessary in the past no longer is. I didn't notice any significant memory leaks in my testing, but if you catch an error on my part please do let me know and I'll correct it.
-  This commit does not adjust the "`blender_imgui.py`" file found in the _root_ of the repo yet, only the one found in `examples\blender_imgui.py`. It seems the one in `examples` is older, before the framerate limit PR, but for some reason I was running into errors I didn't have the time to track down on top of migrating the implementation. I'll get around to updating the root file later, and will commit those changes to the file in `examples` as it seems like that was intended to get updated.
-  The class name for the Blender Imgui implementation is still erroneously called `BaseOpenGLRenderer.` Just didn't get around to renaming it yet, oop! I'll let you choose a different name if you want :p

Also, an adjustment was made to the following code to prevent a crash when unloading the plugin:
```py
     def shutdown_imgui(self):
        for SpaceType, draw_handler in self.draw_handlers.items():
            SpaceType.draw_handler_remove(draw_handler, 'WINDOW') # originally "self.draw_handler," which was throwing an error.
```



This PR has been tested on both the latest LTS of Blender (4.4) and the 4.5 alpha, both in OpenGL and Vulkan backends. It has only been tested on Windows, but it may work fine on Linux as well.